### PR TITLE
Allow user to choose middleware

### DIFF
--- a/src/config/lfm.php
+++ b/src/config/lfm.php
@@ -2,6 +2,7 @@
 
 return [
     'use_package_routes' => true,
+    'middleware' => 'auth',
 
     'images_dir'         => 'public/vendor/laravel-filemanager/images/',
     'images_url'         => '/vendor/laravel-filemanager/images/',

--- a/src/routes.php
+++ b/src/routes.php
@@ -1,5 +1,5 @@
 <?php
-Route::group(array('middleware' => 'auth'), function () // make sure authenticated
+Route::group(array('middleware' => Config::get('lfm.middleware')), function () // make sure authenticated
 {
 
     Route::get('sample-ckeditor-integration', function () {


### PR DESCRIPTION
Not everyone uses the default "auth" middleware. This allows people to change the middleware used without having to make their own routes.