### PR TITLE
Fix typo preventing files from being shown

### DIFF
--- a/src/views/files.blade.php
+++ b/src/views/files.blade.php
@@ -38,7 +38,7 @@
                 <div class="col-sm-6 col-md-2 img-row">
 
                     <div class="thumbnail thumbnail-img text-center" style="border: none;" data-id="{{ basename($file['name']) }}" id="img_thumbnail_{{ $key }}">
-                        <i class="fa <?= $file['icon']; ?> fa-5x" style="cursor:pointer;" onclick="useFile('{!! basename($file) !!}')"></i>
+                        <i class="fa <?= $file['icon']; ?> fa-5x" style="cursor:pointer;" onclick="useFile('{!! basename($file['name']) !!}')"></i>
                     </div>
 
                     <div class="caption text-center">


### PR DESCRIPTION
This is the output from the call to `/laravel-filemanager/jsonfiles?base=%2F&show_list=0&_=1454033741802` when trying to view files (not images).

![image](https://cloud.githubusercontent.com/assets/6479817/12665245/445f7896-c5eb-11e5-921b-cfcab30194c3.png)