### PR TITLE
Use IoC for config resolution, so it can be overridden.

### DIFF
--- a/src/LaravelFilemanagerServiceProvider.php
+++ b/src/LaravelFilemanagerServiceProvider.php
@@ -49,6 +49,11 @@ class LaravelFilemanagerServiceProvider extends ServiceProvider {
         {
             return true;
         });
+
+        $this->app['laravel-filemanager.config'] = $this->app->share(function ()
+        {
+            return Config::get('lfm');
+        });
     }
 
 }

--- a/src/controllers/Controller.php
+++ b/src/controllers/Controller.php
@@ -1,10 +1,21 @@
 <?php namespace Tsawler\Laravelfilemanager\controllers;
 
 use Illuminate\Foundation\Bus\DispatchesJobs;
-use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Foundation\Validation\ValidatesRequests;
+use Illuminate\Routing\Controller as BaseController;
+use Illuminate\Support\Facades\App;
 
 abstract class Controller extends BaseController
 {
     use DispatchesJobs, ValidatesRequests;
+
+    /**
+     * Get the config for a given key, allowing users to override
+     * the config generation via the IoC container.
+     */
+    protected function getConfig($key)
+    {
+        $config = App::make('laravel-filemanager.config');
+        return $config[$key];
+    }
 }

--- a/src/controllers/CropController.php
+++ b/src/controllers/CropController.php
@@ -23,7 +23,7 @@ class CropController extends Controller {
         $image = Input::get('img');
 
         return View::make('laravel-filemanager::crop')
-            ->with('img', Config::get('lfm.images_url') . $dir . "/" . $image)
+            ->with('img', $this->getConfig('images_url') . $dir . "/" . $image)
             ->with('dir', $dir)
             ->with('image', $image);
     }
@@ -49,7 +49,7 @@ class CropController extends Controller {
         // make new thumbnail
         $thumb_img = Image::make(public_path() . $img);
         $thumb_img->fit(200, 200)
-            ->save(base_path() . "/" . Config::get('lfm.images_dir') . $dir . "/thumbs/" . basename($img));
+            ->save(base_path() . "/" . $this->getConfig('images_dir') . $dir . "/thumbs/" . basename($img));
     }
 
 }

--- a/src/controllers/DeleteController.php
+++ b/src/controllers/DeleteController.php
@@ -24,9 +24,9 @@ class DeleteController extends Controller {
     function __construct()
     {
         if (Session::get('lfm_type') == "Images")
-            $this->file_location = Config::get('lfm.images_dir');
+            $this->file_location = $this->getConfig('images_dir');
         else
-            $this->file_location = Config::get('lfm.files_dir');
+            $this->file_location = $this->getConfig('files_dir');
     }
 
 

--- a/src/controllers/DownloadController.php
+++ b/src/controllers/DownloadController.php
@@ -24,9 +24,9 @@ class DownloadController extends Controller {
     function __construct()
     {
         if (Session::get('lfm_type') == "Images")
-            $this->file_location = Config::get('lfm.images_dir');
+            $this->file_location = $this->getConfig('images_dir');
         else
-            $this->file_location = Config::get('lfm.files_dir');
+            $this->file_location = $this->getConfig('files_dir');
     }
 
 

--- a/src/controllers/FolderController.php
+++ b/src/controllers/FolderController.php
@@ -19,9 +19,9 @@ class FolderController extends Controller {
     function __construct()
     {
         if (Session::get('lfm_type') == "Images")
-            $this->file_location = Config::get('lfm.images_dir');
+            $this->file_location = $this->getConfig('images_dir');
         else
-            $this->file_location = Config::get('lfm.files_dir');
+            $this->file_location = $this->getConfig('files_dir');
     }
 
 

--- a/src/controllers/ItemsController.php
+++ b/src/controllers/ItemsController.php
@@ -29,9 +29,9 @@ class ItemsController extends Controller {
     function __construct()
     {
         if (Session::get('lfm_type') == "Images")
-            $this->file_location = Config::get('lfm.images_dir');
+            $this->file_location = $this->getConfig('images_dir');
         else
-            $this->file_location = Config::get('lfm.files_dir');
+            $this->file_location = $this->getConfig('files_dir');
     }
 
 
@@ -60,8 +60,8 @@ class ItemsController extends Controller {
         }
 
         $file_info = [];
-        $icon_array = Config::get('lfm.file_icon_array');
-        $type_array = Config::get('lfm.file_type_array');
+        $icon_array = $this->getConfig('file_icon_array');
+        $type_array = $this->getConfig('file_type_array');
 
         foreach ($files as $file)
         {
@@ -163,9 +163,9 @@ class ItemsController extends Controller {
         }
 
         if ((Session::has('lfm_type')) && (Session::get('lfm_type') == "Images"))
-            $dir_location = Config::get('lfm.images_url');
+            $dir_location = $this->getConfig('images_url');
         else
-            $dir_location = Config::get('lfm.files_url');
+            $dir_location = $this->getConfig('files_url');
 
         if (Input::get('show_list') == 1)
         {

--- a/src/controllers/LfmController.php
+++ b/src/controllers/LfmController.php
@@ -26,10 +26,10 @@ class LfmController extends Controller {
     {
         if ((Session::has('lfm_type')) && (Session::get('lfm_type') == 'Files'))
         {
-            $this->file_location = Config::get('lfm.files_dir');
+            $this->file_location = $this->getConfig('files_dir');
         } else
         {
-            $this->file_location = Config::get('lfm.images_dir');
+            $this->file_location = $this->getConfig('images_dir');
         }
     }
 
@@ -44,11 +44,11 @@ class LfmController extends Controller {
         if ((Input::has('type')) && (Input::get('type') == "Files"))
         {
             Session::put('lfm_type', 'Files');
-            $this->file_location = Config::get('lfm.files_dir');
+            $this->file_location = $this->getConfig('files_dir');
         } else
         {
             Session::put('lfm_type', 'Images');
-            $this->file_location = Config::get('lfm.images_dir');
+            $this->file_location = $this->getConfig('images_dir');
         }
 
         if (Input::has('base'))

--- a/src/controllers/RenameController.php
+++ b/src/controllers/RenameController.php
@@ -18,9 +18,9 @@ class RenameController extends Controller {
     function __construct()
     {
         if (Session::get('lfm_type') == "Images")
-            $this->file_location = Config::get('lfm.images_dir');
+            $this->file_location = $this->getConfig('images_dir');
         else
-            $this->file_location = Config::get('lfm.files_dir');
+            $this->file_location = $this->getConfig('files_dir');
     }
 
 

--- a/src/controllers/ResizeController.php
+++ b/src/controllers/ResizeController.php
@@ -23,8 +23,8 @@ class ResizeController extends Controller {
         $image = Input::get('img');
         $dir = Input::get('dir');
 
-        $original_width = Image::make(base_path() . "/" . Config::get('lfm.images_dir') . $dir . "/" . $image)->width();
-        $original_height = Image::make(base_path() . "/" . Config::get('lfm.images_dir') . $dir . "/" . $image)->height();
+        $original_width = Image::make(base_path() . "/" . $this->getConfig('images_dir') . $dir . "/" . $image)->width();
+        $original_height = Image::make(base_path() . "/" . $this->getConfig('images_dir') . $dir . "/" . $image)->height();
 
         $scaled = false;
 
@@ -49,7 +49,7 @@ class ResizeController extends Controller {
         }
 
         return View::make('laravel-filemanager::resize')
-            ->with('img', Config::get('lfm.images_url') . $dir . "/" . $image)
+            ->with('img', $this->getConfig('images_url') . $dir . "/" . $image)
             ->with('dir', $dir)
             ->with('image', $image)
             ->with('height', number_format($height, 0))

--- a/src/controllers/UploadController.php
+++ b/src/controllers/UploadController.php
@@ -30,12 +30,12 @@ class UploadController extends Controller {
      */
     function __construct()
     {
-        $this->allowed_types = Config::get('lfm.allowed_file_types');
+        $this->allowed_types = $this->getConfig('allowed_file_types');
 
         if (Session::get('lfm_type') == "Images")
-            $this->file_location = Config::get('lfm.images_dir');
+            $this->file_location = $this->getConfig('images_dir');
         else
-            $this->file_location = Config::get('lfm.files_dir');
+            $this->file_location = $this->getConfig('files_dir');
     }
 
 

--- a/src/views/index.blade.php
+++ b/src/views/index.blade.php
@@ -353,16 +353,16 @@
 
         @if ((Session::has('lfm_type')) && (Session::get('lfm_type') == "Images"))
             if (path != '/') {
-                window.opener.CKEDITOR.tools.callFunction(funcNum, '{{ \Config::get('lfm.images_url') }}' + path + "/" + file);
+                window.opener.CKEDITOR.tools.callFunction(funcNum, '{{ array_get(\App::make('laravel-filemanager.config'), 'images_url') }}' + path + "/" + file);
             } else {
-                window.opener.CKEDITOR.tools.callFunction(funcNum, '{{ \Config::get('lfm.images_url') }}' + file);
+                window.opener.CKEDITOR.tools.callFunction(funcNum, '{{ array_get(\App::make('laravel-filemanager.config'), 'images_url') }}' + file);
             }
         @else
             if (path != '/') {
-            window.opener.CKEDITOR.tools.callFunction(funcNum, '{{ \Config::get('lfm.files_url') }}' + path + "/" + file);
-        } else {
-            window.opener.CKEDITOR.tools.callFunction(funcNum, '{{ \Config::get('lfm.files_url') }}' + file);
-        }
+                window.opener.CKEDITOR.tools.callFunction(funcNum, '{{ array_get(\App::make('laravel-filemanager.config'), 'files_url') }}' + path + "/" + file);
+            } else {
+                window.opener.CKEDITOR.tools.callFunction(funcNum, '{{ array_get(\App::make('laravel-filemanager.config'), 'files_url') }}' + file);
+            }
         @endif
         window.close();
     }


### PR DESCRIPTION
Super-simple implementation for overriding the base folders and URLs with a closure, allowing for easy implementation of arbitrarily structured file manager stores. Also a fix for documentation error with upload route.